### PR TITLE
修正proposaltype设置为master之后封面出现的错误

### DIFF
--- a/Style/nudtproposal.cls
+++ b/Style/nudtproposal.cls
@@ -146,7 +146,7 @@
 \def\@title{\NUDT@value@titlemark}
 % 开题报告类型
 \newcommand\proposaltype[1]{%	
-	\ifstrequal{#1}{doctor}{	\def\NUDT@value@proposall{\NUDTunderline{博士}研究生学位论文}	\def\NUDT@value@proposal{博士研究生学位论文}}{	\def\NUDT@value@proposal{硕士研究生学位论文}}
+	\ifstrequal{#1}{doctor}{	\def\NUDT@value@proposall{\NUDTunderline{博士}研究生学位论文}	\def\NUDT@value@proposal{博士研究生学位论文}}{\def\NUDT@value@proposall{\NUDTunderline{硕士}研究生学位论文}	\def\NUDT@value@proposal{硕士研究生学位论文}}
 }
 % 是否启用目录
 \newcommand{\enabletableofcontents}[1]{

--- a/Tex/1_background.tex
+++ b/Tex/1_background.tex
@@ -7,7 +7,7 @@
 
 
 
-\section{文献学位论文选题的立论依据}
+\section{学位论文选题的立论依据}
 
 
 \begin{mdframed}[everyline=true]


### PR DESCRIPTION
当 proposaltype 设置为 mater 之后，封面“硕士研究生学位论文”，这个 pull request 将其修正。